### PR TITLE
Remove definitions from headers to avoid linking errors

### DIFF
--- a/gdigi.h
+++ b/gdigi.h
@@ -42,7 +42,7 @@ gboolean debug_flag_is_set (debug_flags_t flag);
 #define GNX_CABINET_WARP 263
 #define GNX_CHANNEL_FS_MODE 264
 
-unsigned char product_id;
+extern unsigned char product_id;
 
 enum {
   GNX3K_WAH_TYPE_CRY = 129,
@@ -1120,7 +1120,7 @@ enum {
     GENETX_CHANNEL1_CUSTOM = 2,
     GENETX_CHANNEL2_CUSTOM = 3,
     GENETX_CHANNEL_CURRENT = 4
-} ChannelBankIndex;
+};
 
 typedef struct {
     int version;


### PR DESCRIPTION
Those were causing linking errors since they were defined multiple times (whenever it was included somewhere else). `ChannelBankIndex` was removed since it was not used anywhere. `product_id{{ is already defined on gdigi.c
so it was marked as `extern`.